### PR TITLE
#5: Add unit-tests for static helper methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 */bin/*
 */.vs/*
 *.vs/*
+coverage.xml
+CodeCoverage/*

--- a/CSharpKdb.sln
+++ b/CSharpKdb.sln
@@ -2,7 +2,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.30611.23
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "kx", "kx\kx.csproj", "{9325FAD0-FE05-480C-900B-8ED51599F686}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "kx", "kx\kx.csproj", "{9325FAD0-FE05-480C-900B-8ED51599F686}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "kx.Test", "kx.Test\kx.Test.csproj", "{7F243343-0765-4284-BC74-48675C58DE33}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -14,6 +16,10 @@ Global
 		{9325FAD0-FE05-480C-900B-8ED51599F686}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9325FAD0-FE05-480C-900B-8ED51599F686}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9325FAD0-FE05-480C-900B-8ED51599F686}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7F243343-0765-4284-BC74-48675C58DE33}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7F243343-0765-4284-BC74-48675C58DE33}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7F243343-0765-4284-BC74-48675C58DE33}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7F243343-0765-4284-BC74-48675C58DE33}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/kx.Test/Connection/ConnectionArrayTests.cs
+++ b/kx.Test/Connection/ConnectionArrayTests.cs
@@ -1,0 +1,109 @@
+﻿using NUnit.Framework;
+
+namespace kx.Test.Connection
+{
+    [TestFixture]
+    public class ConnectionArrayTests
+    {
+        [Test]
+        public void ConnectionReturnsExpectedLengthForDict()
+        {
+            const int expected = 1;
+
+            c.Dict dict = new c.Dict(new[] { "Key_1" }, new object[] { "Value_1" });
+
+            int count = c.n(dict);
+
+            Assert.AreEqual(expected, count);
+        }
+
+        [Test]
+        public void ConnectionReturnsExpectedLengthForFlip()
+        {
+            const int expected = 1;
+
+            c.Flip flip = new c.Flip(new c.Dict(new[] { "Key_1" }, new object[] { new object[] { "Value_1" } }));
+
+            int count = c.n(flip);
+
+            Assert.AreEqual(expected, count);
+        }
+
+        [Test]
+        public void ConnectionReturnsExpectedLengthForCharArray()
+        {
+            const int expected = 8;
+
+            char[] array = "Aardvark".ToCharArray();
+
+            int count = c.n(array);
+
+            Assert.AreEqual(expected, count);
+        }
+
+        [Test]
+        public void ConnectionReturnsExpectedLengthForObjectArray()
+        {
+            const int expected = 1;
+
+            object[] array = new[] { "Aardvark" };
+
+            int count = c.n(array);
+
+            Assert.AreEqual(expected, count);
+        }
+
+        [Test]
+        public void ConnectionAtReturnsExpectedObjectFromArrayIndex()
+        {
+            const string expected = "foo";
+
+            object result = c.at(new object[] { "foo", "bar" }, 0);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void ConnectionAtReturnsNullIfObjectFromArrayIndexIsNull()
+        {
+            object result = c.at(new object[] { null, "bar" }, 0);
+
+            Assert.IsNull(result);
+        }
+
+        [Test]
+        public void ConnectionAtReturnsNullIfObjectFromArrayIndexIsQNull()
+        {
+            object result = c.at(new object[] { string.Empty, "bar" }, 0);
+
+            Assert.IsNull(result);
+        }
+
+        [Test]
+        public void ConnectionTableReturnsExpectedTableIfObjectIsFlip()
+        {
+            c.Flip flip = new c.Flip(new c.Dict(new[] { "Key_1" }, new object[] { new object[] { "Value_1" } }));
+
+            object result = c.td(flip);
+
+            Assert.IsNotNull(result);
+            Assert.IsTrue(result is c.Flip);
+        }
+
+        [Test]
+        public void ConnectionTableReturnsExpectedTableIfObjectIsDict()
+        {
+            c.Dict dict = new c.Dict
+                (
+                    new c.Flip(new c.Dict(new[] { "Key_1" }, new object[] { new object[] { "Value_1" } })),
+                    new c.Flip(new c.Dict(new[] { "Key_1" }, new object[] { new object[] { "Value_1" } }))
+                );
+
+            object result = c.td(dict);
+
+            Assert.IsNotNull(result);
+            Assert.IsTrue(result is c.Flip);
+        }
+    }
+}

--- a/kx.Test/Connection/ConnectionNullTests.cs
+++ b/kx.Test/Connection/ConnectionNullTests.cs
@@ -1,0 +1,686 @@
+﻿using System;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace kx.Test.Connection
+{
+    [TestFixture]
+    public class ConnectionNullTests
+    {
+        [Test]
+        public void ConnectionGetsExpectedNullValueFromBooleanType()
+        {
+            const bool expected = false;
+
+            var result = c.NULL(typeof(bool));
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void ConnectionGetsExpectedNullValueFromGuidType()
+        {
+            Guid expected = default(Guid);
+
+            var result = c.NULL(typeof(Guid));
+
+            Assert.AreEqual(expected, result);
+
+        }
+
+        [Test]
+        public void ConnectionGetsExpectedNullValueFromByteType()
+        {
+            const byte expected = 0;
+
+            var result = c.NULL(typeof(byte));
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void ConnectionGetsExpectedNullValueFromShortType()
+        {
+            const short expected = short.MinValue;
+
+            var result = c.NULL(typeof(short));
+
+            Assert.AreEqual(expected, result);
+
+        }
+
+        [Test]
+        public void ConnectionGetsExpectedNullValueFromIntType()
+        {
+            const int expected = int.MinValue;
+
+            var result = c.NULL(typeof(int));
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void ConnectionGetsExpectedNullValueFromLongType()
+        {
+            const long expected = long.MinValue;
+
+            var result = c.NULL(typeof(long));
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void ConnectionGetsExpectedNullValueFromFloatType()
+        {
+            const float expected = (float)double.NaN;
+
+            var result = c.NULL(typeof(float));
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void ConnectionGetsExpectedNullValueFromDoubleType()
+        {
+            const double expected = double.NaN;
+
+            var result = c.NULL(typeof(double));
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void ConnectionGetsExpectedNullValueFromCharType()
+        {
+            const char expected = ' ';
+
+            var result = c.NULL(typeof(char));
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void ConnectionGetsExpectedNullValueFromStringType()
+        {
+            const string expected = "";
+
+            var result = c.NULL(typeof(string));
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void ConnectionGetsExpectedNullValueFromDateTimeType()
+        {
+            DateTime expected = new DateTime(0L);
+
+            var result = c.NULL(typeof(DateTime));
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void ConnectionGetsExpectedNullValueFromMonthType()
+        {
+            c.Month expected = new c.Month(int.MinValue);
+
+            var result = c.NULL(typeof(c.Month));
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void ConnectionGetsExpectedNullValueFromDateType()
+        {
+            c.Date expected = new c.Date(int.MinValue);
+
+            var result = c.NULL(typeof(c.Date));
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void ConnectionGetsExpectedNullValueFromKTimespanType()
+        {
+            c.KTimespan expected = new c.KTimespan(long.MinValue);
+
+            var result = c.NULL(typeof(c.KTimespan));
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void ConnectionGetsExpectedNullValueFromMinuteType()
+        {
+            c.Minute expected = new c.Minute(int.MinValue);
+
+            var result = c.NULL(typeof(c.Minute));
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void ConnectionGetsExpectedNullValueFromSecondType()
+        {
+            c.Second expected = new c.Second(int.MinValue);
+
+            var result = c.NULL(typeof(c.Second));
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void ConnectionGetsExpectedNullValueFromTimeSpanType()
+        {
+            TimeSpan expected = new TimeSpan(long.MinValue);
+
+            var result = c.NULL(typeof(TimeSpan));
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void ConnectionGetsExpectedNullValueFromCSharpSpecificType()
+        {
+            var result = c.NULL(typeof(Task));
+
+            Assert.IsNull(result);
+        }
+
+        [Test]
+        public void ConnectionGetsExpectedNullValueFromCSharpCustomType()
+        {
+            var result = c.NULL(typeof(TestType));
+
+            Assert.IsNull(result);
+        }
+
+        [Test]
+        public void ConnectionGetsExpectedNullValueForNullCharacterId()
+        {
+            var result = c.NULL(' ');
+
+            Assert.IsNull(result);
+        }
+
+        [Test]
+        public void ConnectionGetExpectedNullValueForBooleanCharacterId()
+        {
+            const bool expected = false;
+
+            var result = c.NULL('b');
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void ConnectionGetExpectedNullValueForGuidCharacterId()
+        {
+            Guid expected = default(Guid);
+
+            var result = c.NULL('g');
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void ConnectionGetExpectedNullValueForByteCharacterId()
+        {
+            const byte expected = 0;
+
+            var result = c.NULL('x');
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void ConnectionGetExpectedNullValueForShortCharacterId()
+        {
+            const short expected = short.MinValue;
+
+            var result = c.NULL('h');
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void ConnectionGetExpectedNullValueForIntCharacterId()
+        {
+            const int expected = int.MinValue;
+
+            var result = c.NULL('i');
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void ConnectionGetExpectedNullValueForLongCharacterId()
+        {
+            const long expected = long.MinValue;
+
+            var result = c.NULL('j');
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void ConnectionGetExpectedNullValueForFloatCharacterId()
+        {
+            const float expected = (float)double.NaN;
+
+            var result = c.NULL('e');
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void ConnectionGetExpectedNullValueForDoubleCharacterId()
+        {
+            const double expected = double.NaN;
+
+            var result = c.NULL('f');
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void ConnectionGetExpectedNullValueForCharCharacterId()
+        {
+            const char expected = ' ';
+
+            var result = c.NULL('c');
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void ConnectionGetExpectedNullValueForStringCharacterId()
+        {
+            const string expected = "";
+
+            var result = c.NULL('s');
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void ConnectionGetsExpectedNullValueForDateTimeCharacterId()
+        {
+            DateTime expected = new DateTime(0L);
+
+            var result = c.NULL('p');
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void ConnectionGetsExpectedNullValueForMonthCharacterId()
+        {
+            c.Month expected = new c.Month(int.MinValue);
+
+            var result = c.NULL('m');
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void ConnectionGetsExpectedNullValueForDateCharacterId()
+        {
+            c.Date expected = new c.Date(int.MinValue);
+
+            var result = c.NULL('d');
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void ConnectionGetsExpectedNullValueForKTimeSpanCharacterId()
+        {
+            c.KTimespan expected = new c.KTimespan(long.MinValue);
+
+            var result = c.NULL('n');
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void ConnectionGetsExpectedNullValueForMinuteCharacterId()
+        {
+            c.Minute expected = new c.Minute(int.MinValue);
+
+            var result = c.NULL('u');
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void ConnectionGetsExpectedNullValueForSecondCharacterId()
+        {
+            c.Second expected = new c.Second(int.MinValue);
+
+            var result = c.NULL('v');
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void ConnectionGetsExpectedNullValueForTimeSpanCharacterId()
+        {
+            TimeSpan expected = new TimeSpan(long.MinValue);
+
+            var result = c.NULL('t');
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void ConnectionNullThrowsIfUnrecognisedCharacterId()
+        {
+            Assert.Throws<ArgumentException>(() => c.NULL('@'));
+        }
+
+        [Test]
+        public void ConnectionIsQNullReturnsFalseForBoolean()
+        {
+            bool input = false;
+
+            Assert.IsFalse(c.qn(input));
+        }
+
+        [Test]
+        public void ConnectionIsQNullReturnsTrueForGuid()
+        {
+            Guid input = default(Guid);
+
+            Assert.IsTrue(c.qn(input));
+        }
+
+        [Test]
+        public void ConnectionIsQNullReturnsFalseForByte()
+        {
+            byte input = 0;
+
+            Assert.IsFalse(c.qn(input));
+        }
+
+        [Test]
+        public void ConnectionIsQNullReturnsTrueForShort()
+        {
+            short input = short.MinValue;
+
+            Assert.IsTrue(c.qn(input));
+        }
+
+        [Test]
+        public void ConnectionIsQNullReturnsTrueForInt()
+        {
+            int input = int.MinValue;
+
+            Assert.IsTrue(c.qn(input));
+        }
+
+        [Test]
+        public void ConnectionIsQNullReturnsTrueForLong()
+        {
+            long input = long.MinValue;
+
+            Assert.IsTrue(c.qn(input));
+        }
+
+        [Test]
+        public void ConnectionIsQNullReturnsTrueForFloat()
+        {
+            float input = (float)double.NaN;
+
+            Assert.IsTrue(c.qn(input));
+        }
+
+        [Test]
+        public void ConnectionIsQNullReturnsTrueForDouble()
+        {
+            double input = double.NaN;
+
+            Assert.IsTrue(c.qn(input));
+        }
+
+        [Test]
+        public void ConnectionIsQNullReturnsTrueForChar()
+        {
+            char input = ' ';
+
+            Assert.IsTrue(c.qn(input));
+        }
+
+        [Test]
+        public void ConnectionIsQNullReturnsTrueForString()
+        {
+            string input = string.Empty;
+
+            Assert.IsTrue(c.qn(input));
+        }
+
+        [Test]
+        public void ConnectionIsQNullReturnsTrueForDateTime()
+        {
+            DateTime input = new DateTime(0L);
+
+            Assert.IsTrue(c.qn(input));
+        }
+
+        [Test]
+        public void ConnectionIsQNullReturnsTrueForMonth()
+        {
+            c.Month input = new c.Month(int.MinValue);
+
+            Assert.IsTrue(c.qn(input));
+        }
+
+        [Test]
+        public void ConnectionIsQNullReturnsTrueForDate()
+        {
+            c.Date input = new c.Date(int.MinValue);
+
+            Assert.IsTrue(c.qn(input));
+        }
+
+        [Test]
+        public void ConnectionIsQNullReturnsTrueForKTimespan()
+        {
+            c.KTimespan input = new c.KTimespan(long.MinValue);
+
+            Assert.IsTrue(c.qn(input));
+        }
+
+        [Test]
+        public void ConnectionIsQNullReturnsTrueForMinute()
+        {
+            c.Minute input = new c.Minute(int.MinValue);
+
+            Assert.IsTrue(c.qn(input));
+        }
+
+        [Test]
+        public void ConnectionIsQNullReturnsTrueForSecond()
+        {
+            c.Second input = new c.Second(int.MinValue);
+
+            Assert.IsTrue(c.qn(input));
+        }
+
+        [Test]
+        public void ConnectionIsQNullReturnsTrueForTimespan()
+        {
+            TimeSpan input = new TimeSpan(long.MinValue);
+
+            Assert.IsTrue(c.qn(input));
+        }
+
+        [Test]
+        public void ConnectionIsQNullReturnsFalseForBooleanArray()
+        {
+            bool[] input = Array.Empty<bool>();
+
+            Assert.IsFalse(c.qn(input));
+        }
+
+        [Test]
+        public void ConnectionIsQNullReturnsFalseForGuidArray()
+        {
+            Guid[] input = Array.Empty<Guid>();
+
+            Assert.IsFalse(c.qn(input));
+        }
+
+        [Test]
+        public void ConnectionIsQNullReturnsFalseForByteArray()
+        {
+            byte[] input = Array.Empty<byte>();
+
+            Assert.IsFalse(c.qn(input));
+        }
+
+        [Test]
+        public void ConnectionIsQNullReturnsFalseForShortArray()
+        {
+            short[] input = Array.Empty<short>();
+
+            Assert.IsFalse(c.qn(input));
+        }
+
+        [Test]
+        public void ConnectionIsQNullReturnsFalseForIntArray()
+        {
+            int[] input = Array.Empty<int>();
+
+            Assert.IsFalse(c.qn(input));
+        }
+
+        [Test]
+        public void ConnectionIsQNullReturnsFalseForLongArray()
+        {
+            long[] input = Array.Empty<long>();
+
+            Assert.IsFalse(c.qn(input));
+        }
+
+        [Test]
+        public void ConnectionIsQNullReturnsFalseForFloatArray()
+        {
+            float[] input = Array.Empty<float>();
+
+            Assert.IsFalse(c.qn(input));
+        }
+
+        [Test]
+        public void ConnectionIsQNullReturnsFalseForDoubleArray()
+        {
+            double[] input = Array.Empty<double>();
+
+            Assert.IsFalse(c.qn(input));
+        }
+
+        [Test]
+        public void ConnectionIsQNullReturnsFalseForCharArray()
+        {
+            char[] input = Array.Empty<char>();
+
+            Assert.IsFalse(c.qn(input));
+        }
+
+        [Test]
+        public void ConnectionIsQNullReturnsFalseForStringArray()
+        {
+            string[] input = Array.Empty<string>();
+
+            Assert.IsFalse(c.qn(input));
+        }
+
+        [Test]
+        public void ConnectionIsQNullReturnsFalseForDateTimeArray()
+        {
+            DateTime[] input = Array.Empty<DateTime>();
+
+            Assert.IsFalse(c.qn(input));
+        }
+
+        [Test]
+        public void ConnectionIsQNullReturnsFalseForDateArray()
+        {
+            c.Date[] input = Array.Empty<c.Date>();
+
+            Assert.IsFalse(c.qn(input));
+        }
+
+        [Test]
+        public void ConnectionIsQNullReturnsFalseForMinuteArray()
+        {
+            c.Minute[] input = Array.Empty<c.Minute>();
+
+            Assert.IsFalse(c.qn(input));
+        }
+
+        [Test]
+        public void ConnectionIsQNullReturnsFalseForSecondArray()
+        {
+            c.Second[] input = Array.Empty<c.Second>();
+
+            Assert.IsFalse(c.qn(input));
+        }
+
+        [Test]
+        public void ConnectionIsQNullReturnsFalseForKTimeSpanArray()
+        {
+            c.KTimespan[] input = Array.Empty<c.KTimespan>();
+
+            Assert.IsFalse(c.qn(input));
+        }
+
+        [Test]
+        public void ConnectionIsQNullReturnsFalseForTimeSpanArray()
+        {
+            TimeSpan[] input = Array.Empty<TimeSpan>();
+
+            Assert.IsFalse(c.qn(input));
+        }
+
+        [Test]
+        public void ConnectionIsQNullReturnsFalseForDict()
+        {
+            c.Dict input = new c.Dict(new string[] { }, new object[] { });
+
+            Assert.IsFalse(c.qn(input));
+        }
+
+        [Test]
+        public void ConnectionIsQNullReturnsFalseForFlip()
+        {
+            c.Flip input = new c.Flip(new c.Dict(new string[] { }, new object[] { }));
+
+            Assert.IsFalse(c.qn(input));
+        }
+
+        [Test]
+        public void ConnectionIsQNullReturnsFalseForCSharpSpecificType()
+        {
+            Task input = new Task(() => { });
+
+            Assert.IsFalse(c.qn(input));
+        }
+
+        [Test]
+        public void ConnectionIsQNullReturnsFalseForCSharpCustomType()
+        {
+            TestType input = new TestType();
+
+            Assert.IsFalse(c.qn(input));
+        }
+
+        [Test]
+        public void ConnectionIsQNullReturnsFalseForNull()
+        {
+            Assert.IsFalse(c.qn(null));
+        }
+
+        private class TestType { }
+    }
+}

--- a/kx.Test/Scripts/GenerateLocalReport.ps1
+++ b/kx.Test/Scripts/GenerateLocalReport.ps1
@@ -1,0 +1,24 @@
+﻿Param
+(
+    [Parameter(Mandatory=$True, Position=1)]
+    [string] $TargetAssembly,
+
+	[Parameter(Mandatory=$True, Position=2)]
+	[string] $TargetTestProj,
+
+	[Parameter(Mandatory=$True, Position=3)]
+	[string] $BuildConfiguration
+)
+
+$nugetPackagesPath = "C:\Users\$($env:USERNAME)\.nuget\packages"
+
+$openCover = "$($nugetPackagesPath)\opencover\4.7.922\tools\OpenCover.Console.exe"
+$reportGenerator = "$($nugetPackagesPath)\reportgenerator\4.7.1\tools\net47\ReportGenerator.exe"
+
+## OpenCover to consume results of executing tests
+&$openCover -target:'C:\Program Files\dotnet\dotnet.exe' -targetargs:"test $TargetTestProj --no-build --no-restore -p:Configuration=$BuildConfiguration" -output:Coverage.xml -register:user -oldStyle -filter:"+[$TargetAssembly]*"
+
+## Generate Test Coverage report from OpenCover coverage.xml file
+&$reportGenerator -reports:Coverage.xml -targetdir:CodeCoverage
+
+

--- a/kx.Test/kx.Test.csproj
+++ b/kx.Test/kx.Test.csproj
@@ -1,0 +1,37 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>1701;1702;1591</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>1701;1702;1591</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="NunitXml.TestLogger" Version="2.1.41" />
+    <PackageReference Include="OpenCover" Version="4.7.922" />
+    <PackageReference Include="OpenCoverToCoberturaConverter" Version="0.3.4" />
+    <PackageReference Include="ReportGenerator" Version="4.7.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\kx\kx.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Scripts\" />
+  </ItemGroup>
+
+</Project>

--- a/kx/c.cs
+++ b/kx/c.cs
@@ -46,7 +46,7 @@ namespace kx
 
 		private static double nf = double.NaN;
 
-		private static object[] NU = new object[20]
+		private static object[] KNullValues = new object[20]
 		{
 			null,
 			false,
@@ -69,6 +69,9 @@ namespace kx
 			new Second(ni),
 			new TimeSpan(nj)
 		};
+
+		private static readonly char[] KNullCharIds = " bg xhijefcspmdznuvt"
+			.ToCharArray();
 
 		private static DateTime za = DateTime.MinValue.AddTicks(1L);
 
@@ -377,15 +380,36 @@ namespace kx
 		/// </returns>
 		public static object NULL(Type t)
 		{
-			for (int i = 0; i < NU.Length; i++)
+			for (int i = 0; i < KNullValues.Length; i++)
 			{
-				if (NU[i] != null &&
-					t == NU[i].GetType())
+				if (KNullValues[i] != null &&
+					t == KNullValues[i].GetType())
 				{
-					return NU[i];
+					return KNullValues[i];
 				}
 			}
 			return null;
+		}
+
+		/// <summary>
+		/// Gest the null object for the specified <see cref="char"/> id.
+		/// </summary>
+		/// <param name="c">The character id.</param>
+		/// <returns>
+		/// Instance of null object of specified KDB+ type.
+		/// </returns>
+		/// <exception cref="ArgumentException"><paramref name="c"/> character is not recognised.</exception>
+		public static object NULL(char c)
+		{
+			int index = Array.IndexOf(KNullCharIds, c);
+
+			if (index == -1)
+			{
+				throw new ArgumentException($"Unable to find KDB+ null for character {c}, not recognised",
+					nameof(c));
+			}
+
+			return KNullValues[index];
 		}
 
 		/// <summary>
@@ -403,7 +427,7 @@ namespace kx
 			int t = -c.t(x);
 			if (t == 2 || t > 4)
 			{
-				return x.Equals(NU[t]);
+				return x.Equals(KNullValues[t]);
 			}
 			return false;
 		}
@@ -1329,11 +1353,6 @@ namespace kx
 		private static string i2(int i)
 		{
 			return $"{i:00}";
-		}
-
-		private static object NULL(char c)
-		{
-			return NU[" bg xhijefcspmdznuvt".IndexOf(c)];
 		}
 
 		private static long clampDT(long j)


### PR DESCRIPTION
Add uni-test library kx.Test.csproj

Add 3rd party libraries and script for generating OpenCover test coverage report

Renamed private static fields for readability
- KNullValues
- KNullCharIds