### PR TITLE
install java 17 on travis build

### DIFF
--- a/tools/travis-ci-install-sonar.sh
+++ b/tools/travis-ci-install-sonar.sh
@@ -1,6 +1,15 @@
   
 #!/bin/sh
-echo "Starting install..."
+if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
+    echo "Updating Java for Ubuntu 16.04.7"
+    apt-get update
+    apt-get install -y software-properties-common
+    add-apt-repository -y ppa:linuxuprising/java
+    apt-get update
+    echo oracle-java17-installer shared/accepted-oracle-license-v1-3 select true | /usr/bin/debconf-set-selections
+    apt install -y oracle-java17-installer --install-recommends
+fi
+echo "Starting sonar install..."
 wget -O sonar.zip https://github.com/SonarSource/sonar-scanner-msbuild/releases/download/5.0.4.24009/sonar-scanner-msbuild-5.0.4.24009-netcoreapp3.0.zip
 echo "Unzipping..."
 unzip -qq sonar.zip -d tools/sonar


### PR DESCRIPTION
tested with docker image ubuntu:16.04
travis errors with
"java.lang.UnsupportedClassVersionError: org/sonar/batch/bootstrapper/EnvironmentInformation has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 55.0" 55 = Java 11
61 = Java 17